### PR TITLE
Feat: add Opus 4.5, update pricing, and audit a package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,9 +910,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -930,9 +927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -950,9 +944,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +961,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,9 +978,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,9 +2129,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const MODELS = [
     name: "Claude Opus 4.6",
     reasoning: true,
     input: ["text", "image"] as ("text" | "image")[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
     contextWindow: 1000000,
     maxTokens: 128000,
   },
@@ -21,7 +21,7 @@ const MODELS = [
     name: "Claude Sonnet 4.6",
     reasoning: true,
     input: ["text", "image"] as ("text" | "image")[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
     contextWindow: 1000000,
     maxTokens: 64000,
   },
@@ -30,10 +30,19 @@ const MODELS = [
     name: "Claude Haiku 4.5",
     reasoning: true,
     input: ["text", "image"] as ("text" | "image")[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    cost: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
     contextWindow: 200000,
     maxTokens: 64000,
   },
+  {
+    id: "claude-opus-4-5-20251101",
+    name: "Claude Opus 4.5",
+    reasoning: true,
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+  }
 ];
 
 function ensureClaudeCodeSymlink() {
@@ -42,7 +51,7 @@ function ensureClaudeCodeSymlink() {
   if (existsSync(target) && !existsSync(link)) {
     try {
       symlinkSync(target, link);
-    } catch {}
+    } catch { }
   }
 }
 


### PR DESCRIPTION
## Why? 
- I find Opus 4.5 to be more consistent to work with (except for UIs, the current frontier models will always be better), and so I find that it's worth being included.
- I'm a stats-maxing guy sometimes, so maybe adding the pricing would help?
## What got changed?
- `index.ts` - update model and pricing
- `package-lock.json` - apparently `basic-ftp` has a major vulnerability.