### PR TITLE
add Claude Opus 4.7 to hardcoded MODELS list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,15 @@ import { streamAnthropicOAuth } from "./stream.js";
 
 const MODELS = [
   {
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    reasoning: true,
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 128000,
+  },
+  {
     id: "claude-opus-4-6",
     name: "Claude Opus 4.6",
     reasoning: true,


### PR DESCRIPTION
Opus 4.7 is defined in pi-ai (as of pi-mono commit a91978c) but this extension replaces the Anthropic provider with a hardcoded 3-model list, causing Opus 4.7 to disappear from the registry and enabledModels patterns like "anthropic/claude-opus-4-7" to fail to resolve.

Add it to the list, same flat-rate cost entry as the other Max models.