### PR TITLE
fix: preserve thinkingLevelMap so xhigh thinking level is available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ const DEFAULT_OPUS_4_8: NonNullable<ProviderConfig["models"]>[number] = {
   name: "Claude Opus 4.8",
   api: "anthropic-messages",
   reasoning: true,
+  thinkingLevelMap: { xhigh: "xhigh" },
   input: ["text", "image"],
   cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   contextWindow: 1000000,
@@ -38,16 +39,12 @@ function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
   const models: NonNullable<ProviderConfig["models"]> = modelRegistry
     .getAll()
     .filter((model) => model.provider === "anthropic")
+    // Spread the full registry model so every field (thinkingLevelMap,
+    // baseUrl, headers, compat, and anything added in future) propagates
+    // automatically instead of being silently dropped by a hand-picked list.
     .map((model) => ({
-      id: model.id,
-      name: model.name,
+      ...model,
       api: model.api ?? "anthropic-messages",
-      reasoning: model.reasoning,
-      input: model.input,
-      cost: model.cost,
-      contextWindow: model.contextWindow,
-      maxTokens: model.maxTokens,
-      compat: model.compat,
     }));
 
   if (!models.some((model) => model.id === DEFAULT_OPUS_4_8.id)) {


### PR DESCRIPTION
## Bug

The `xhigh` thinking level is never available when using this extension — only `off/minimal/low/medium/high` show up in the Shift+Tab cycle.

## Root Cause

Pi derives the available thinking levels via `getSupportedThinkingLevels(model)` in `@earendil-works/pi-ai`, which only includes `xhigh` when `model.thinkingLevelMap.xhigh` exists.

`getAnthropicModels()` rebuilt each registry model from a **hand-picked list of fields**, and `thinkingLevelMap` was not among them:

```ts
.map((model) => ({
  id: model.id,
  name: model.name,
  api: model.api ?? "anthropic-messages",
  reasoning: model.reasoning,
  input: model.input,
  cost: model.cost,
  contextWindow: model.contextWindow,
  maxTokens: model.maxTokens,
  compat: model.compat,
  // thinkingLevelMap (and baseUrl/headers) silently dropped
}));
```

Since `thinkingLevelMap` was missing, `getSupportedThinkingLevels` filtered out `xhigh` and the UI never offered it. The `DEFAULT_OPUS_4_8` fallback also lacked `thinkingLevelMap`.

## Fix

Rather than add `thinkingLevelMap` to the cherry-picked list (which would leave the same class of bug waiting for the next new field), **spread the full registry model** so every field propagates automatically for all current and future models:

```ts
.map((model) => ({
  ...model,
  api: model.api ?? "anthropic-messages",
}));
```

This also restores `baseUrl`/`headers`, which were being dropped too. Excess-property checks don't apply to object spreads, so this stays type-safe against `ProviderModelConfig`.

Also added `thinkingLevelMap: { xhigh: "xhigh" }` to the `DEFAULT_OPUS_4_8` fallback so `xhigh` works even when the model isn't present in the registry.

## Verification

- `tsc -p tsconfig.json --noEmit` passes cleanly.
- After the change, selecting an Anthropic model that declares `xhigh` support exposes `xhigh` in the Shift+Tab thinking-level cycle.

## Steps to Reproduce (before fix)

1. Install the extension and `/login anthropic`
2. Select Claude Opus
3. Press Shift+Tab to cycle thinking levels
4. Observe `xhigh` is missing from the cycle