### PR TITLE
fix: tool calls crash or mangle under fine-grained tool streaming

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -24,7 +24,12 @@ import { buildAnthropicSystemPrompt } from "./prompt.js";
 const REQUIRED_BETAS = [
   "claude-code-20250219",
   "oauth-2025-04-20",
-  "fine-grained-tool-streaming-2025-05-14",
+  // fine-grained-tool-streaming removed: it ships the model's raw, unvalidated
+  // tool-input JSON. For large edits full of quotes/newlines the streamed
+  // string escaping breaks, so a field (e.g. edit.oldText) swallows the rest of
+  // the structure — surfacing as either a hard JSON.parse crash or a wrong-shape
+  // schema-validation failure. Default streaming has the server validate/buffer
+  // tool JSON, guaranteeing well-formed, correctly-structured input.
   "interleaved-thinking-2025-05-14",
 ] as const;
 
@@ -57,10 +62,7 @@ function makeDefaultHeaders(
     headers["user-agent"] = USER_AGENT;
     headers["x-app"] = "cli";
   } else {
-    headers["anthropic-beta"] = [
-      "fine-grained-tool-streaming-2025-05-14",
-      "interleaved-thinking-2025-05-14",
-    ].join(",");
+    headers["anthropic-beta"] = ["interleaved-thinking-2025-05-14"].join(",");
   }
 
   if (options?.headers) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -170,7 +170,12 @@ export function streamAnthropicOAuth(
         };
       }
 
-      const anthropicStream = client.messages.stream(params, {
+      // Raw stream instead of the MessageStream helper: MessageStream
+      // accumulates tool_use input and JSON.parses it on content_block_stop,
+      // which throws under fine-grained-tool-streaming (input may be invalid
+      // mid-flight) and aborts the turn. The raw stream yields the same
+      // RawMessageStreamEvents; tool args are already parsed leniently below.
+      const anthropicStream = await client.messages.create(params, {
         signal: options?.signal,
       });
       stream.push({ type: "start", partial: output });


### PR DESCRIPTION
Fixes #11.

## Symptoms

With this package (OAuth path), tool calls intermittently either:
- **crash the turn** with a bare `Unexpected non-whitespace character after JSON at position N`, or
- **fail schema validation** — e.g. an `edit` whose `edits:[{oldText,newText}]` arrives flattened into a top-level `oldText` that has literally swallowed `","newText":"...","path":"..."}]` as trailing text, so validation reports `must have required properties edits` / `must not have additional properties`.

Both have the same cause.

## Cause

`REQUIRED_BETAS` enables `fine-grained-tool-streaming-2025-05-14`, which streams the model's tool-input JSON **without** the default server-side validation/buffering — clients may receive partial, invalid, or mis-escaped JSON. For large tool arguments full of quotes/newlines (code edits), the streamed string escaping breaks and one field absorbs the rest of the structure. Depending on exactly how it breaks you get a hard `JSON.parse` throw (crash) or accidentally-parseable-but-wrong structure (validation failure).

It's compounded by consuming the stream via `client.messages.stream()`, whose `MessageStream` helper strict-`JSON.parse`s accumulated `tool_use` input on `content_block_stop` and throws.

For contrast, the SDK/Pi built-in `anthropic` provider does neither, and the same backend is stable there.

## Fix

1. **Drop `fine-grained-tool-streaming-2025-05-14`** (the root cause). Default streaming still streams deltas, but the server validates/buffers tool JSON so the accumulated input is well-formed and correctly structured. The latency cost is negligible for typical tool inputs; correctness of `edit`/`write` payloads matters far more.
2. **Use the raw streaming endpoint** instead of the `MessageStream` helper, as defense-in-depth: same `RawMessageStreamEvent`s the loop already handles, no internal strict accumulation. Tool args are already parsed leniently in the loop.

```diff
   const REQUIRED_BETAS = [
     "claude-code-20250219",
     "oauth-2025-04-20",
-    "fine-grained-tool-streaming-2025-05-14",
     "interleaved-thinking-2025-05-14",
   ] as const;

-  const anthropicStream = client.messages.stream(params, {
-    signal: options?.signal,
-  });
+  const anthropicStream = await client.messages.create(params, {
+    signal: options?.signal,
+  });
```

If you want to keep fine-grained streaming for latency, I can gate it behind an opt-in flag instead of removing it — let me know your preference.

**Verification:** `npm run check` (tsc) passes against `@anthropic-ai/sdk@^0.52.0`.