### PR TITLE
Make Pi prompt rewrite configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+.test-dist/
 *.tgz
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ Claude Pro/Max
 > [!NOTE]
 > Anthropic auth changes are closely monitored for quick compatibility updates.
 
+## System prompt rewriting
+
+When using Claude Pro/Max OAuth, the extension prepends Claude Code identity text and rewrites standalone `Pi` / `pi` references in Pi's system prompt to `Claude Code`. The rewrite mode defaults to `aggressive`:
+
+```bash
+PI_ANTHROPIC_OAUTH_REWRITE_MODE=aggressive
+```
+
+Available modes:
+
+| Mode | Behavior |
+|------|----------|
+| `aggressive` | Default. Replaces standalone `Pi` / `pi` wherever the word-boundary pattern matches. |
+| `path-safe` | Avoids replacing `Pi` / `pi` immediately after `/` or `\`, preserving path segments like `/srv/dev/pi-foo`. |
+| `technical-safe` | Avoids replacing `Pi` / `pi` next to common technical-token separators: `/`, `\`, `.`, `@`, `:`, `_`, `-`. |
+| `custom` | Uses `PI_ANTHROPIC_OAUTH_REWRITE_PATTERN` as the replacement regex. |
+
+Custom patterns can be a regex source or a JavaScript-style regex literal. The `g` flag is added automatically when omitted:
+
+```bash
+PI_ANTHROPIC_OAUTH_REWRITE_MODE=custom
+PI_ANTHROPIC_OAUTH_REWRITE_PATTERN='(?<![/\\])\b[Pp]i\b'
+# or
+PI_ANTHROPIC_OAUTH_REWRITE_PATTERN='/\bpi\b/gi'
+```
+
+There is no separate off mode. If you need to disable rewriting entirely, use a custom pattern that never matches, such as `(?!)`.
+
 ## Extra models
 
 To add another Anthropic model, create `~/.pi/agent/models.json`:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ When using Claude Pro/Max OAuth, the extension prepends Claude Code identity tex
 PI_ANTHROPIC_OAUTH_REWRITE_MODE=aggressive
 ```
 
+Other modes are opt-in and avoid rewriting some technical strings such as paths, package names, or repository names. If OAuth starts failing, switch back to `aggressive`.
+
 Available modes:
 
 | Mode | Behavior |
@@ -66,7 +68,7 @@ PI_ANTHROPIC_OAUTH_REWRITE_PATTERN='(?<![/\\])\b[Pp]i\b'
 PI_ANTHROPIC_OAUTH_REWRITE_PATTERN='/\bpi\b/gi'
 ```
 
-There is no separate off mode. If you need to disable rewriting entirely, use a custom pattern that never matches, such as `(?!)`.
+There is no separate off mode. If you need to disable rewriting entirely, use a custom pattern that never matches, such as `(?!)`. Disabling or weakening the rewrite may affect OAuth compatibility.
 
 ## Extra models
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   },
   "scripts": {
     "check": "tsc -p tsconfig.json --noEmit",
+    "test": "node -e \"require('node:fs').rmSync('.test-dist', { recursive: true, force: true })\" && tsc -p tsconfig.json --outDir .test-dist && node --test test/*.test.mjs",
     "pack:check": "npm pack --dry-run",
-    "prepublishOnly": "npm run check && npm run pack:check"
+    "prepublishOnly": "npm run check && npm test && npm run pack:check"
   },
   "pi": {
     "extensions": [

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -6,6 +6,25 @@ const PI_REMOVAL_ANCHORS = [
   "badlogic/pi-mono",
 ] as const;
 
+export const PI_REWRITE_MODE_ENV = "PI_ANTHROPIC_OAUTH_REWRITE_MODE";
+export const PI_REWRITE_PATTERN_ENV = "PI_ANTHROPIC_OAUTH_REWRITE_PATTERN";
+
+export type PiRewriteMode = "aggressive" | "path-safe" | "technical-safe" | "custom";
+
+const DEFAULT_PI_REWRITE_MODE: PiRewriteMode = "aggressive";
+const PI_REWRITE_PATTERN_SOURCES: Record<Exclude<PiRewriteMode, "custom">, string> = {
+  aggressive: String.raw`\b[Pp]i\b`,
+  "path-safe": String.raw`(?<![/\\])\b[Pp]i\b`,
+  "technical-safe": String.raw`(?<![/\\.@:_-])\b[Pp]i\b(?![/\\.@:_-])`,
+};
+
+const PI_REWRITE_MODES = new Set<PiRewriteMode>([
+  "aggressive",
+  "path-safe",
+  "technical-safe",
+  "custom",
+]);
+
 type MessageContentBlock = {
   type: string;
   text?: string;
@@ -42,7 +61,10 @@ export function buildAnthropicSystemPrompt(
   return blocks.length > 0 ? blocks : undefined;
 }
 
-function sanitizeSystemText(text: string): string {
+export function sanitizeSystemText(
+  text: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
   const paragraphs = text.split(/\n\n+/);
   const filtered = paragraphs.filter((paragraph) => {
     const lower = paragraph.toLowerCase();
@@ -52,7 +74,56 @@ function sanitizeSystemText(text: string): string {
 
   return filtered
     .join("\n\n")
-    .replace(/\bpi\b/g, "Claude Code")
-    .replace(/\bPi\b/g, "Claude Code")
+    .replace(resolvePiRewritePattern(env), "Claude Code")
     .trim();
+}
+
+function resolvePiRewritePattern(env: NodeJS.ProcessEnv): RegExp {
+  const mode = parsePiRewriteMode(env[PI_REWRITE_MODE_ENV]);
+  if (mode === "custom") return compileCustomPiRewritePattern(env[PI_REWRITE_PATTERN_ENV]);
+  return new RegExp(PI_REWRITE_PATTERN_SOURCES[mode], "g");
+}
+
+function parsePiRewriteMode(value: string | undefined): PiRewriteMode {
+  if (!value?.trim()) return DEFAULT_PI_REWRITE_MODE;
+  const mode = value.trim().toLowerCase();
+  if (PI_REWRITE_MODES.has(mode as PiRewriteMode)) return mode as PiRewriteMode;
+  throw new Error(
+    `Invalid ${PI_REWRITE_MODE_ENV}: ${value}. Expected one of ${Array.from(PI_REWRITE_MODES).join(", ")}.`,
+  );
+}
+
+function compileCustomPiRewritePattern(value: string | undefined): RegExp {
+  const pattern = value?.trim();
+  if (!pattern) {
+    throw new Error(`${PI_REWRITE_PATTERN_ENV} must be set when ${PI_REWRITE_MODE_ENV}=custom.`);
+  }
+
+  const parsed = parseRegexLiteral(pattern) ?? { source: pattern, flags: "" };
+  const flags = parsed.flags.includes("g") ? parsed.flags : `${parsed.flags}g`;
+  try {
+    return new RegExp(parsed.source, flags);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid ${PI_REWRITE_PATTERN_ENV}: ${message}`);
+  }
+}
+
+function parseRegexLiteral(value: string): { source: string; flags: string } | undefined {
+  if (!value.startsWith("/")) return undefined;
+
+  for (let index = value.length - 1; index > 0; index--) {
+    if (value[index] !== "/" || isEscaped(value, index)) continue;
+    return { source: value.slice(1, index), flags: value.slice(index + 1) };
+  }
+
+  return undefined;
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === "\\"; cursor--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
 }

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PI_REWRITE_MODE_ENV,
+  PI_REWRITE_PATTERN_ENV,
+  sanitizeSystemText,
+} from "../.test-dist/prompt.js";
+
+function rewriteEnv(mode, pattern) {
+  return {
+    [PI_REWRITE_MODE_ENV]: mode,
+    ...(pattern === undefined ? {} : { [PI_REWRITE_PATTERN_ENV]: pattern }),
+  };
+}
+
+test("default rewrite mode remains aggressive", () => {
+  assert.equal(
+    sanitizeSystemText("Work in /srv/dev/pi-foo.\n\nPi can use pi."),
+    "Work in /srv/dev/Claude Code-foo.\n\nClaude Code can use Claude Code.",
+  );
+});
+
+test("path-safe mode preserves pi immediately after slashes", () => {
+  assert.equal(
+    sanitizeSystemText(
+      "Work in /srv/dev/pi-foo and C:\\Users\\pi\\repo.\n\nPi can use pi.",
+      rewriteEnv("path-safe"),
+    ),
+    "Work in /srv/dev/pi-foo and C:\\Users\\pi\\repo.\n\nClaude Code can use Claude Code.",
+  );
+});
+
+test("technical-safe mode preserves common technical tokens", () => {
+  assert.equal(
+    sanitizeSystemText(
+      "Pi pi /pi .pi pi-foo npm:pi-anthropic-oauth @scope/pi-helper foo_pi pi:bar",
+      rewriteEnv("technical-safe"),
+    ),
+    "Claude Code Claude Code /pi .pi pi-foo npm:pi-anthropic-oauth @scope/pi-helper foo_pi pi:bar",
+  );
+});
+
+test("custom mode accepts a regex source", () => {
+  assert.equal(
+    sanitizeSystemText("Pi pi", rewriteEnv("custom", "\\bPi\\b")),
+    "Claude Code pi",
+  );
+});
+
+test("custom mode accepts a regex literal and adds the global flag", () => {
+  assert.equal(
+    sanitizeSystemText("Pi pi PI", rewriteEnv("custom", "/\\bpi\\b/i")),
+    "Claude Code Claude Code Claude Code",
+  );
+});
+
+test("custom mode can disable rewriting with a never-matching pattern", () => {
+  assert.equal(
+    sanitizeSystemText("Pi pi", rewriteEnv("custom", "(?!)")),
+    "Pi pi",
+  );
+});
+
+test("invalid rewrite configuration fails clearly", () => {
+  assert.throws(
+    () => sanitizeSystemText("Pi", rewriteEnv("unknown")),
+    /Invalid PI_ANTHROPIC_OAUTH_REWRITE_MODE/,
+  );
+
+  assert.throws(
+    () => sanitizeSystemText("Pi", rewriteEnv("custom")),
+    /PI_ANTHROPIC_OAUTH_REWRITE_PATTERN must be set/,
+  );
+
+  assert.throws(
+    () => sanitizeSystemText("Pi", rewriteEnv("custom", "(")),
+    /Invalid PI_ANTHROPIC_OAUTH_REWRITE_PATTERN/,
+  );
+});


### PR DESCRIPTION
## Summary

This makes the OAuth system prompt rewrite configurable while keeping the existing aggressive rewrite as the default.

The extension currently rewrites standalone `Pi` / `pi` references in Pi's system prompt to `Claude Code`. With word-boundary matching, that can also alter technical context such as path segments, package names, or repository names. For example, a path like `/srv/dev/pi-foo` can become `/srv/dev/Claude Code-foo`.

## Changes

- Add `PI_ANTHROPIC_OAUTH_REWRITE_MODE` with these modes:
  - `aggressive`: current/default behavior
  - `path-safe`: avoids replacing `Pi` / `pi` immediately after `/` or `\`
  - `technical-safe`: avoids replacing `Pi` / `pi` next to common technical-token separators
  - `custom`: uses `PI_ANTHROPIC_OAUTH_REWRITE_PATTERN`
- Support custom regex sources and JavaScript-style regex literals, adding the `g` flag when omitted.
- Document the new configuration in the README.
- Add prompt rewrite tests for default, safer, custom, and invalid configurations.

There is intentionally no separate `off` mode; users can use a never-matching custom pattern such as `(?!)` if they need to disable rewriting.

## Compatibility

Default behavior is unchanged unless users set the new environment variables.

## Testing

```bash
npm run prepublishOnly
```
