### PR TITLE
fix: load under pi 0.80.x (AuthStorage / ModelRegistry.create removed)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import { existsSync, symlinkSync } from "node:fs";
+import { existsSync, readFileSync, symlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
-  AuthStorage,
-  ModelRegistry,
   type ExtensionAPI,
   type ProviderConfig,
 } from "@earendil-works/pi-coding-agent";
@@ -49,17 +47,27 @@ function ensureClaudeCodeSymlink() {
 }
 
 function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
-  const modelRegistry = ModelRegistry.create(AuthStorage.inMemory());
-  const models: NonNullable<ProviderConfig["models"]> = modelRegistry
-    .getAll()
-    .filter((model) => model.provider === "anthropic")
-    // Spread the full registry model so every field (thinkingLevelMap,
-    // baseUrl, headers, compat, and anything added in future) propagates
-    // automatically instead of being silently dropped by a hand-picked list.
-    .map((model) => ({
-      ...model,
-      api: model.api ?? "anthropic-messages",
-    }));
+  const models: NonNullable<ProviderConfig["models"]> = [];
+
+  // Pi 0.80.x removed the synchronous `ModelRegistry.create(AuthStorage.inMemory())`
+  // facade this used to read the host's known anthropic models from. Read the
+  // catalog the host maintains on disk instead, so newer models (sonnet, haiku, …)
+  // stay selectable; fall back to the bundled defaults if it's missing or its
+  // shape changes — this must never throw at extension-load time.
+  try {
+    const storePath = join(homedir(), ".pi", "agent", "models-store.json");
+    const store = JSON.parse(readFileSync(storePath, "utf8"));
+    const stored = store?.anthropic?.models;
+    if (Array.isArray(stored)) {
+      for (const model of stored) {
+        if (!model?.id) continue;
+        if (model.provider && model.provider !== "anthropic") continue;
+        models.push({ ...model, api: model.api ?? "anthropic-messages" });
+      }
+    }
+  } catch {
+    // best-effort: the defaults below are always registered
+  }
 
   for (const defaultModel of DEFAULT_MODELS) {
     if (!models.some((model) => model.id === defaultModel.id)) {


### PR DESCRIPTION
### Problem

On `@earendil-works/pi-coding-agent` **0.80.x**, the extension fails to load:

```
Failed to load extension ".../pi-anthropic-oauth/src/index.ts":
Cannot read properties of undefined (reading 'inMemory')
```

0.80.x removed the synchronous compatibility facade this relied on:

- `AuthStorage` is no longer exported (so `AuthStorage.inMemory()` dereferences `undefined`), and
- `ModelRegistry.create(...)` was replaced by a `new ModelRegistry(runtime)` constructor.

`getAnthropicModels()` calls `ModelRegistry.create(AuthStorage.inMemory())` at registration time, so the whole provider fails to register and Claude Pro/Max login/streaming becomes unavailable.

### Fix

Read the host's on-disk model catalog (`~/.pi/agent/models-store.json` → `anthropic.models`) instead of the removed in-memory registry. This keeps full model coverage (sonnet, haiku, opus variants, …) rather than collapsing to a hard-coded list.

The read is wrapped in `try/catch` so it can **never throw at extension-load time**; if the store is missing or its shape changes, the bundled `DEFAULT_MODELS` are still registered as a fallback. Existing merge-in-defaults behaviour is preserved.

Only `src/index.ts` changes; no dependency or API-surface changes.

### Verification

`pi --offline --list-models` before/after: the `Failed to load extension` error is gone and the anthropic provider registers with the full catalog (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`, …).

> Note: verified against pi 0.80.10. The removed `streamSimpleAnthropic` (pi-ai 0.80.x) is only referenced on the non-anthropic delegation branch and is out of scope here.
