### PR TITLE
Update Claude Code OAuth compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ pi update npm:pi-anthropic-oauth
 > [!NOTE]
 > Anthropic auth changes are closely monitored for quick compatibility updates.
 
+## Claude Code compatibility
+
+The extension detects the installed `claude --version` once at startup and uses
+that version in its Claude Code-compatible inference headers. If `claude` is not
+available on `PATH`, it falls back to the version tested by this release.
+
+To override detection explicitly:
+
+```bash
+PI_ANTHROPIC_OAUTH_CLAUDE_CODE_VERSION=2.1.214 pi
+```
+
+Modern models marked by Pi as adaptive-thinking models use adaptive thinking
+and effort controls. Older Claude models continue to use token-budget thinking.
+
 ## System prompt rewriting
 
 When using Claude Pro/Max OAuth, the extension prepends Claude Code identity text and rewrites standalone `Pi` / `pi` references in Pi's system prompt to `Claude Code`. The rewrite mode defaults to `aggressive`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.52.0"
+        "@anthropic-ai/sdk": "^0.112.3"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.8",
@@ -25,12 +25,24 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
-      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "version": "0.112.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.112.3.tgz",
+      "integrity": "sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg==",
       "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -496,7 +508,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1082,7 +1093,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1205,6 +1216,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,6 +1236,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1239,6 +1256,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,6 +1276,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,6 +1296,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,7 +1382,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2494,7 +2519,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2561,7 +2585,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2641,13 +2664,6 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@smithy/core": {
       "version": "3.29.4",
@@ -2777,6 +2793,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -2802,16 +2824,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -2852,19 +2864,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -2900,16 +2899,6 @@
         }
       }
     },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2926,6 +2915,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -2994,24 +2989,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/google-auth-library": {
       "version": "10.9.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
@@ -3039,13 +3016,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3075,26 +3045,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -3109,7 +3059,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -3148,42 +3097,6 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3275,45 +3188,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -3369,18 +3243,20 @@
       ],
       "license": "MIT"
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -3429,9 +3305,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3454,9 +3330,8 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.52.0"
+    "@anthropic-ai/sdk": "^0.112.3"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "^0.80.8",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,11 +1,12 @@
 import { createServer } from "node:http";
+import { execFileSync } from "node:child_process";
 import type {
   OAuthCredentials,
   OAuthLoginCallbacks,
 } from "@earendil-works/pi-ai";
 
 const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
-const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
+const AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 const REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 const SCOPES = [
@@ -16,7 +17,9 @@ const SCOPES = [
   "user:mcp_servers",
   "user:file_upload",
 ].join(" ");
-const USER_AGENT = "claude-code/2.1.97";
+const FALLBACK_CLAUDE_CODE_VERSION = "2.1.214";
+const CLAUDE_CODE_VERSION_ENV = "PI_ANTHROPIC_OAUTH_CLAUDE_CODE_VERSION";
+const USER_AGENT = buildClaudeCodeUserAgent(resolveClaudeCodeVersion());
 const CALLBACK_PORT = 53692;
 const CALLBACK_HOST = "127.0.0.1";
 const LOCAL_CALLBACK_TIMEOUT = 5 * 60 * 1000;
@@ -24,6 +27,33 @@ const MAX_TOKEN_RETRIES = 2;
 const INITIAL_RETRY_DELAY_MS = 5000;
 
 export { USER_AGENT };
+
+export function parseClaudeCodeVersion(output: string): string | undefined {
+  return output.match(/\b(\d+\.\d+\.\d+)\b/)?.[1];
+}
+
+export function buildClaudeCodeUserAgent(version: string): string {
+  return `claude-cli/${version} (external, cli)`;
+}
+
+function resolveClaudeCodeVersion(): string {
+  const configured = process.env[CLAUDE_CODE_VERSION_ENV]?.trim();
+  if (configured) {
+    const parsed = parseClaudeCodeVersion(configured);
+    if (parsed) return parsed;
+  }
+
+  try {
+    const output = execFileSync("claude", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    });
+    return parseClaudeCodeVersion(output) ?? FALLBACK_CLAUDE_CODE_VERSION;
+  } catch {
+    return FALLBACK_CLAUDE_CODE_VERSION;
+  }
+}
 
 type ParsedAuthInput = { code: string; state: string };
 type LocalAuthorization = {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -34,6 +34,18 @@ const claudeCodeTools = [
   "Grep",
   "Glob",
   "AskUserQuestion",
+  "EnterPlanMode",
+  "ExitPlanMode",
+  "NotebookEdit",
+  "Skill",
+  "Agent",
+  "Task",
+  "TaskCreate",
+  "TaskGet",
+  "TaskList",
+  "TaskOutput",
+  "TaskStop",
+  "TaskUpdate",
   "TodoWrite",
   "WebFetch",
   "WebSearch",
@@ -134,6 +146,27 @@ export function convertPiMessagesToAnthropic(
       for (const block of message.content) {
         if (block.type === "text" && block.text.trim()) {
           blocks.push({ type: "text", text: sanitizeSurrogates(block.text) });
+        } else if (block.type === "thinking") {
+          if (block.redacted && block.thinkingSignature) {
+            blocks.push({
+              type: "redacted_thinking",
+              data: block.thinkingSignature,
+            } as ContentBlockParam);
+          } else if (block.thinkingSignature) {
+            blocks.push({
+              type: "thinking",
+              thinking: sanitizeSurrogates(block.thinking),
+              signature: block.thinkingSignature,
+            } as ContentBlockParam);
+          } else if (block.thinking.trim()) {
+            // An interrupted stream may not have received a signature. Sending
+            // it as a thinking block would make the next request invalid, so
+            // retain the visible content as ordinary assistant text instead.
+            blocks.push({
+              type: "text",
+              text: sanitizeSurrogates(block.thinking),
+            });
+          }
         } else if (block.type === "toolCall") {
           const anthropicId = getAnthropicToolId(block.id);
           blocks.push({

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,115 @@
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  Api,
+  Context,
+  Model,
+  SimpleStreamOptions,
+  ThinkingLevel,
+} from "@earendil-works/pi-ai";
+
+export const REQUIRED_OAUTH_BETAS = [
+  "claude-code-20250219",
+  "oauth-2025-04-20",
+  "interleaved-thinking-2025-05-14",
+  "context-management-2025-06-27",
+] as const;
+
+type ThinkingConfig =
+  | { type: "adaptive"; display: "summarized" }
+  | {
+      type: "enabled";
+      budget_tokens: number;
+      display: "summarized";
+    };
+
+export type ThinkingRequest = {
+  thinking?: ThinkingConfig;
+  outputConfig?: { effort: string };
+};
+
+const DEFAULT_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
+  minimal: 1024,
+  low: 4096,
+  medium: 10240,
+  high: 20480,
+  xhigh: 32000,
+  max: 32000,
+};
+
+export function buildThinkingRequest(
+  model: Model<Api>,
+  options: SimpleStreamOptions | undefined,
+  maxTokens: number,
+): ThinkingRequest {
+  const level = options?.reasoning;
+  if (!level || !model.reasoning || maxTokens <= 1) return {};
+
+  const compat = model.compat as
+    | { forceAdaptiveThinking?: boolean }
+    | undefined;
+  if (compat?.forceAdaptiveThinking === true) {
+    return {
+      thinking: { type: "adaptive", display: "summarized" },
+      outputConfig: { effort: mapThinkingLevelToEffort(model, level) },
+    };
+  }
+
+  const configuredBudget = (
+    options.thinkingBudgets as Partial<Record<ThinkingLevel, number>> | undefined
+  )?.[level];
+  const requestedBudget =
+    configuredBudget ?? DEFAULT_THINKING_BUDGETS[level];
+
+  return {
+    thinking: {
+      type: "enabled",
+      budget_tokens: Math.min(requestedBudget, maxTokens - 1),
+      display: "summarized",
+    },
+  };
+}
+
+export function mapThinkingLevelToEffort(
+  model: Model<Api>,
+  level: ThinkingLevel,
+): string {
+  const mapped = model.thinkingLevelMap?.[level];
+  if (typeof mapped === "string") return mapped;
+
+  switch (level) {
+    case "minimal":
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+    case "xhigh":
+    case "max":
+      return "high";
+  }
+}
+
+export function createClaudeCodeSessionId(context: Context): string {
+  const firstTimestamp = context.messages[0]?.timestamp;
+  if (firstTimestamp === undefined) return randomUUID();
+
+  const bytes = createHash("sha256")
+    .update("pi-anthropic-oauth\0")
+    .update(String(firstTimestamp))
+    .digest()
+    .subarray(0, 16);
+
+  // Produce an RFC 4122 UUID while keeping the identifier deterministic for
+  // every request that belongs to the same persisted Pi conversation.
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -19,18 +19,11 @@ import {
   type IndexedBlock,
 } from "./convert.js";
 import { buildAnthropicSystemPrompt } from "./prompt.js";
-
-const REQUIRED_BETAS = [
-  "claude-code-20250219",
-  "oauth-2025-04-20",
-  // fine-grained-tool-streaming removed: it ships the model's raw, unvalidated
-  // tool-input JSON. For large edits full of quotes/newlines the streamed
-  // string escaping breaks, so a field (e.g. edit.oldText) swallows the rest of
-  // the structure — surfacing as either a hard JSON.parse crash or a wrong-shape
-  // schema-validation failure. Default streaming has the server validate/buffer
-  // tool JSON, guaranteeing well-formed, correctly-structured input.
-  "interleaved-thinking-2025-05-14",
-] as const;
+import {
+  buildThinkingRequest,
+  createClaudeCodeSessionId,
+  REQUIRED_OAUTH_BETAS,
+} from "./request.js";
 
 function mapStopReason(reason: string | null | undefined): StopReason {
   switch (reason) {
@@ -58,6 +51,7 @@ function headersToRecord(headers: Headers): Record<string, string> {
 function makeDefaultHeaders(
   isOAuth: boolean,
   options?: SimpleStreamOptions,
+  sessionId?: string,
 ): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
@@ -65,9 +59,10 @@ function makeDefaultHeaders(
   };
 
   if (isOAuth) {
-    headers["anthropic-beta"] = REQUIRED_BETAS.join(",");
+    headers["anthropic-beta"] = REQUIRED_OAUTH_BETAS.join(",");
     headers["user-agent"] = USER_AGENT;
     headers["x-app"] = "cli";
+    if (sessionId) headers["X-Claude-Code-Session-Id"] = sessionId;
   } else {
     headers["anthropic-beta"] = ["interleaved-thinking-2025-05-14"].join(",");
   }
@@ -127,7 +122,11 @@ export function streamAnthropicOAuth(
       }
 
       const isOAuth = isClaudeOAuthAccessToken(apiKey);
-      const defaultHeaders = makeDefaultHeaders(isOAuth, options);
+      const defaultHeaders = makeDefaultHeaders(
+        isOAuth,
+        options,
+        createClaudeCodeSessionId(context),
+      );
 
       if (isOAuth) defaultHeaders.authorization = `Bearer ${apiKey}`;
 
@@ -154,25 +153,12 @@ export function streamAnthropicOAuth(
       if (context.tools?.length)
         params.tools = convertPiToolsToAnthropic(context.tools, isOAuth);
 
-      if (options?.reasoning && model.reasoning && maxTokens > 1) {
-        const defaultBudgets: Record<string, number> = {
-          minimal: 1024,
-          low: 4096,
-          medium: 10240,
-          high: 20480,
-          xhigh: 32000,
-        };
-        const customBudget =
-          options.thinkingBudgets?.[
-            options.reasoning as keyof typeof options.thinkingBudgets
-          ];
-        const requestedBudget =
-          customBudget ?? defaultBudgets[options.reasoning] ?? 10240;
-
-        params.thinking = {
-          type: "enabled",
-          budget_tokens: Math.min(requestedBudget, maxTokens - 1),
-        };
+      const thinkingRequest = buildThinkingRequest(model, options, maxTokens);
+      if (thinkingRequest.thinking) {
+        params.thinking = thinkingRequest.thinking as never;
+      }
+      if (thinkingRequest.outputConfig) {
+        params.output_config = thinkingRequest.outputConfig as never;
       }
 
       // Raw stream instead of the MessageStream helper: MessageStream
@@ -241,6 +227,19 @@ export function streamAnthropicOAuth(
               type: "thinking",
               thinking: "",
               thinkingSignature: "",
+              index: event.index,
+            } as IndexedBlock);
+            stream.push({
+              type: "thinking_start",
+              contentIndex: output.content.length - 1,
+              partial: output,
+            });
+          } else if (event.content_block.type === "redacted_thinking") {
+            output.content.push({
+              type: "thinking",
+              thinking: "",
+              thinkingSignature: event.content_block.data,
+              redacted: true,
               index: event.index,
             } as IndexedBlock);
             stream.push({

--- a/test/auth.test.mjs
+++ b/test/auth.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  USER_AGENT,
+  buildClaudeCodeUserAgent,
+  parseClaudeCodeVersion,
+} from "../.test-dist/auth.js";
+
+test("parses Claude Code version output", () => {
+  assert.equal(parseClaudeCodeVersion("2.1.214 (Claude Code)"), "2.1.214");
+  assert.equal(parseClaudeCodeVersion("claude version unknown"), undefined);
+});
+
+test("builds the inference User-Agent used by Claude Code", () => {
+  assert.equal(
+    buildClaudeCodeUserAgent("2.1.214"),
+    "claude-cli/2.1.214 (external, cli)",
+  );
+  assert.match(USER_AGENT, /^claude-cli\/\d+\.\d+\.\d+ \(external, cli\)$/);
+});

--- a/test/convert.test.mjs
+++ b/test/convert.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { convertPiMessagesToAnthropic } from "../.test-dist/convert.js";
+
+function assistant(content) {
+  return {
+    role: "assistant",
+    content,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 1,
+  };
+}
+
+test("replays signed thinking blocks unchanged", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      assistant([
+        {
+          type: "thinking",
+          thinking: "summary",
+          thinkingSignature: "signed-payload",
+        },
+      ]),
+    ],
+    true,
+  );
+
+  assert.deepEqual(converted, [
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "summary",
+          signature: "signed-payload",
+        },
+      ],
+    },
+  ]);
+});
+
+test("replays redacted thinking as its opaque payload", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      assistant([
+        {
+          type: "thinking",
+          thinking: "",
+          thinkingSignature: "encrypted-payload",
+          redacted: true,
+        },
+      ]),
+    ],
+    true,
+  );
+
+  assert.deepEqual(converted[0].content, [
+    { type: "redacted_thinking", data: "encrypted-payload" },
+  ]);
+});
+
+test("degrades unsigned partial thinking to assistant text", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [assistant([{ type: "thinking", thinking: "partial reasoning" }])],
+    true,
+  );
+
+  assert.deepEqual(converted[0].content, [
+    { type: "text", text: "partial reasoning" },
+  ]);
+});

--- a/test/request.test.mjs
+++ b/test/request.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REQUIRED_OAUTH_BETAS,
+  buildThinkingRequest,
+  createClaudeCodeSessionId,
+} from "../.test-dist/request.js";
+
+function model(overrides = {}) {
+  return {
+    id: "claude-opus-4-5",
+    name: "Claude",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 32_000,
+    ...overrides,
+  };
+}
+
+test("OAuth requests include the current Claude Code baseline betas", () => {
+  assert.deepEqual(REQUIRED_OAUTH_BETAS, [
+    "claude-code-20250219",
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "context-management-2025-06-27",
+  ]);
+});
+
+test("adaptive models use effort instead of budget_tokens", () => {
+  assert.deepEqual(
+    buildThinkingRequest(
+      model({
+        id: "claude-opus-4-8",
+        compat: { forceAdaptiveThinking: true },
+        thinkingLevelMap: { xhigh: "xhigh" },
+      }),
+      { reasoning: "xhigh" },
+      32_000,
+    ),
+    {
+      thinking: { type: "adaptive", display: "summarized" },
+      outputConfig: { effort: "xhigh" },
+    },
+  );
+});
+
+test("legacy models retain bounded token-budget thinking", () => {
+  assert.deepEqual(
+    buildThinkingRequest(
+      model(),
+      { reasoning: "high", thinkingBudgets: { high: 50_000 } },
+      10_000,
+    ),
+    {
+      thinking: {
+        type: "enabled",
+        budget_tokens: 9_999,
+        display: "summarized",
+      },
+    },
+  );
+});
+
+test("session IDs are stable for a persisted Pi conversation", () => {
+  const first = {
+    systemPrompt: "system",
+    messages: [{ role: "user", content: "hello", timestamp: 1234 }],
+  };
+  const resumed = {
+    systemPrompt: "changed",
+    messages: [
+      { role: "user", content: "hello", timestamp: 1234 },
+      { role: "user", content: "again", timestamp: 5678 },
+    ],
+  };
+
+  const sessionId = createClaudeCodeSessionId(first);
+  assert.equal(sessionId, createClaudeCodeSessionId(resumed));
+  assert.match(
+    sessionId,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  );
+});


### PR DESCRIPTION
## Summary

- detect the installed Claude Code version and use its current inference User-Agent format
- update the OAuth endpoint and baseline beta headers
- use adaptive thinking plus effort for compatible models while retaining token budgets for legacy models
- preserve signed and redacted thinking blocks across tool rounds
- add stable per-conversation Claude Code session IDs and current canonical tool names
- upgrade the Anthropic SDK and document the version override

## Validation

- npm run check
- npm test (16 tests)
- npm run pack:check
- npm audit (0 vulnerabilities)
- Pi model discovery
- live Claude Opus 4.8 OAuth smoke test with adaptive thinking