### PR TITLE
Fix sanitizeSurrogates destroying valid surrogate pairs (all non-BMP characters turned into U+FFFD)

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -32,7 +32,15 @@ type MessageContentBlock = {
 };
 
 export function sanitizeSurrogates(text: string): string {
-  return text.replace(/[\uD800-\uDFFF]/g, "\uFFFD");
+  // Replace only *unpaired* surrogates: a high surrogate not followed by a low
+  // surrogate, or a low surrogate not preceded by a high surrogate. Valid
+  // surrogate pairs (non-BMP characters such as emoji) must pass through
+  // untouched. Equivalent to String.prototype.toWellFormed(), which requires
+  // Node 20+ while this package supports Node >=18.
+  return text.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    "\uFFFD",
+  );
 }
 
 export function buildAnthropicSystemPrompt(

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -3,8 +3,31 @@ import assert from "node:assert/strict";
 import {
   PI_REWRITE_MODE_ENV,
   PI_REWRITE_PATTERN_ENV,
+  sanitizeSurrogates,
   sanitizeSystemText,
 } from "../.test-dist/prompt.js";
+
+test("preserves valid surrogate pairs (non-BMP characters)", () => {
+  assert.equal(sanitizeSurrogates("\u{1F680}"), "\u{1F680}");
+  assert.equal(sanitizeSurrogates("a\u{1F355}b\u{1F408}c"), "a\u{1F355}b\u{1F408}c");
+});
+
+test("leaves BMP text untouched", () => {
+  assert.equal(sanitizeSurrogates("\u2615\uFE0F \u26A0 \u2192"), "\u2615\uFE0F \u26A0 \u2192");
+});
+
+test("replaces unpaired surrogates", () => {
+  assert.equal(sanitizeSurrogates("\uD800"), "\uFFFD");
+  assert.equal(sanitizeSurrogates("\uDC00"), "\uFFFD");
+  assert.equal(sanitizeSurrogates("\uDC00\uD800"), "\uFFFD\uFFFD"); // reversed pair
+});
+
+test("replaces unpaired surrogates adjacent to valid pairs", () => {
+  assert.equal(sanitizeSurrogates("\u{1F680}\uD800"), "\u{1F680}\uFFFD");
+  assert.equal(sanitizeSurrogates("\uD800\u{1F680}"), "\uFFFD\u{1F680}");
+  assert.equal(sanitizeSurrogates("\u{1F680}\uDC00"), "\u{1F680}\uFFFD");
+  assert.equal(sanitizeSurrogates("\uD800\uD800\uDC00"), "\uFFFD\u{10000}");
+});
 
 function rewriteEnv(mode, pattern) {
   return {


### PR DESCRIPTION
## Summary

Every character outside the Basic Multilingual Plane (U+10000 and above) is currently replaced by **two** U+FFFD replacement characters before the request reaches the Anthropic API. Emoji, astral-plane symbols and non-BMP scripts are silently destroyed in everything the model reads: user messages, assistant messages, thinking blocks and tool results (9 call sites in `convert.ts`). It presents as the model being unable to see emoji that are plainly present in a file it just read.

## Root cause

```ts
export function sanitizeSurrogates(text: string): string {
  return text.replace(/[\uD800-\uDFFF]/g, "\uFFFD");
}
```

## Fix

Replace only *unpaired* surrogates: a high surrogate not followed by a low surrogate, or a low surrogate not preceded by a high one. This keeps the original safety property (no unpaired surrogate ever leaves the function) while passing valid non-BMP characters through untouched.

Behaviour is byte-identical to `String.prototype.toWellFormed()` (verified against it on all test cases, including a reversed pair and unpaired surrogates adjacent to valid pairs). I used the explicit regex because `toWellFormed()` needs Node 20+ and the package declares `engines: { node: ">=18" }` — happy to switch to `toWellFormed()` instead if you'd rather bump the engine floor (Node 18 is EOL since April 2025).

| input | before | after |
|---|---|---|
| `U+1F680` (rocket) | `U+FFFD U+FFFD` | `U+1F680` |
| lone high `U+D800` | `U+FFFD` | `U+FFFD` |
| lone low `U+DC00` | `U+FFFD` | `U+FFFD` |
| `U+1F680` + lone `U+D800` | `U+FFFD ×3` | `U+1F680 U+FFFD` |