### PR TITLE
Fix requests the API rejects and restore prompt caching

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -25,7 +25,49 @@ const INITIAL_RETRY_DELAY_MS = 5000;
 
 export { USER_AGENT };
 
-type ParsedAuthInput = { code: string; state: string };
+const MAX_RETRY_DELAY_MS = 30_000;
+const MANUAL_SETTLE_GRACE_MS = 10_000;
+
+class TokenHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "TokenHttpError";
+  }
+}
+
+// Only network blips and server-side faults deserve the grace window on refresh.
+// A 400 invalid_grant (revoked session, rotated refresh token) never recovers.
+function isTransientTokenError(error: unknown): boolean {
+  if (error instanceof TokenHttpError) {
+    return error.status === 429 || error.status >= 500;
+  }
+  return true;
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.min(Math.max(seconds, 0) * 1000, MAX_RETRY_DELAY_MS);
+  }
+  // RFC 9110 also allows an HTTP-date, which Number() turns into NaN - and
+  // setTimeout(NaN) fires immediately, hammering a server that just asked to
+  // be backed off.
+  const at = Date.parse(value);
+  if (Number.isNaN(at)) return undefined;
+  return Math.min(Math.max(at - Date.now(), 0), MAX_RETRY_DELAY_MS);
+}
+
+type ParsedAuthInput = {
+  code: string;
+  state: string;
+  // Origin+path the code was actually issued against, when the user pasted a
+  // full callback URL. The token exchange must echo the same redirect_uri.
+  redirectUri?: string;
+};
 type LocalAuthorization = {
   redirectUri: string;
   waitForCallback: () => Promise<string | null>;
@@ -45,67 +87,92 @@ export async function loginAnthropic(
   let authInput: string | null = null;
   let redirectUri = REDIRECT_URI;
 
+  // Only failure to *start* the local server is a reason to fall back to the
+  // manual paste flow. Everything after this point is a real error and must
+  // propagate - the old blanket catch swallowed cancellations and aborts too,
+  // which made the whole manualError path below dead code.
+  let localAuthorization: LocalAuthorization | null = null;
   try {
-    const localAuthorization = await createLocalAuthorization(state);
-    redirectUri = localAuthorization.redirectUri;
-
-    callbacks.onAuth({
-      url: makeAuthorizeUrl(challenge, state, redirectUri),
-      instructions:
-        "Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
-    });
-
-    if (callbacks.onManualCodeInput) {
-      let manualInput: string | undefined;
-      let manualError: Error | undefined;
-      const manualPromise = callbacks
-        .onManualCodeInput()
-        .then((input) => {
-          manualInput = input;
-          localAuthorization.cancel();
-        })
-        .catch((err) => {
-          manualError =
-            err instanceof Error ? err : new Error(String(err));
-          localAuthorization.cancel();
-        });
-
-      const callbackResult = await localAuthorization.waitForCallback();
-
-      if (manualError) throw manualError;
-
-      if (callbackResult) {
-        authInput = callbackResult;
-      } else if (manualInput) {
-        authInput = manualInput;
-      }
-
-      if (!authInput) {
-        await manualPromise;
-        if (manualError) throw manualError;
-        if (manualInput) authInput = manualInput;
-      }
-    } else {
-      authInput = await localAuthorization.waitForCallback();
-    }
+    localAuthorization = await createLocalAuthorization(state);
   } catch {
+    localAuthorization = null;
+  }
+
+  try {
+    if (localAuthorization) {
+      const local = localAuthorization;
+      redirectUri = local.redirectUri;
+
+      callbacks.onAuth({
+        url: makeAuthorizeUrl(challenge, state, redirectUri),
+        instructions:
+          "Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
+      });
+
+      if (callbacks.onManualCodeInput) {
+        let manualInput: string | undefined;
+        let manualError: Error | undefined;
+        const manualPromise = callbacks
+          .onManualCodeInput()
+          .then((input) => {
+            manualInput = input;
+            local.cancel();
+          })
+          .catch((err) => {
+            manualError =
+              err instanceof Error ? err : new Error(String(err));
+            local.cancel();
+          });
+
+        const callbackResult = await local.waitForCallback();
+
+        if (manualError) throw manualError;
+
+        if (callbackResult) {
+          authInput = callbackResult;
+        } else if (manualInput) {
+          authInput = manualInput;
+        }
+
+        if (!authInput) {
+          // The local callback timed out while the paste prompt is still open.
+          // Give it a moment to settle, but never block login forever on a
+          // prompt the user may have walked away from.
+          await Promise.race([manualPromise, settleGrace()]);
+          if (manualError) throw manualError;
+          if (manualInput) authInput = manualInput;
+        }
+      } else {
+        authInput = await local.waitForCallback();
+      }
+    }
+  } finally {
+    // Without this the HTTP server keeps listening and the 5-minute timer stays
+    // armed on every failure path: the process cannot exit, port 53692 stays
+    // bound, and a retried /login hits EADDRINUSE for the rest of the session.
+    localAuthorization?.cancel();
   }
 
   if (!authInput) {
-    redirectUri = REDIRECT_URI;
     callbacks.onAuth({
-      url: makeAuthorizeUrl(challenge, state, redirectUri),
+      url: makeAuthorizeUrl(challenge, state, REDIRECT_URI),
       instructions:
         "Sign in with Claude, then paste the full callback URL or the code#state value.",
     });
     authInput = await callbacks.onPrompt({
       message: "Paste the callback URL or code#state:",
     });
+    redirectUri = REDIRECT_URI;
   }
 
   const parsed = parseAuthInput(authInput);
   if (!parsed) throw new Error("Could not parse authorization callback input.");
   if (parsed.state !== state) throw new Error("OAuth state mismatch.");
+
+  // A user who completed the browser flow against the localhost URL before the
+  // fallback appeared holds a code issued for that redirect_uri; exchanging it
+  // under the default one fails with invalid_grant. Trust the pasted URL.
+  const exchangeRedirectUri = parsed.redirectUri ?? redirectUri;
 
   const tokenResponse = await fetchWithRetry(
     TOKEN_URL,
@@ -117,7 +184,7 @@ export async function loginAnthropic(
         client_id: CLIENT_ID,
         code: parsed.code,
         state: parsed.state,
-        redirect_uri: redirectUri,
+        redirect_uri: exchangeRedirectUri,
         code_verifier: verifier,
       }),
       signal: callbacks.signal,
@@ -156,11 +223,15 @@ export async function refreshAnthropicToken(
       },
       "Token refresh",
     );
-  } catch {
-    if (credentials.expires > Date.now()) {
+  } catch (error) {
+    // A permanently rejected refresh token must surface so the user is asked to
+    // log in again. Extending the grace window on it produces an endless
+    // 30-second retry loop against a credential that will never work.
+    if (isTransientTokenError(error) && credentials.expires > Date.now()) {
       return { ...credentials, expires: Date.now() + 30_000 };
     }
-    throw new Error("Token refresh failed and token has expired.");
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Token refresh failed: ${detail}`);
   }
 
   const data = (await response.json()) as {
@@ -209,28 +280,31 @@ async function fetchWithRetry(
 
     const bodyText = await response.text();
 
+    const failure = new TokenHttpError(
+      `${label} failed: ${response.status} ${bodyText}`,
+      response.status,
+    );
+
     const shouldRetry = response.headers.get("x-should-retry");
-    if (shouldRetry === "false") {
-      throw new Error(`${label} failed: ${response.status} ${bodyText}`);
-    }
+    if (shouldRetry === "false") throw failure;
 
     if (
       attempt < MAX_TOKEN_RETRIES &&
       (response.status === 429 || response.status >= 500)
     ) {
-      const retryAfter = response.headers.get("retry-after");
-      const delayMs = retryAfter
-        ? Math.min(Number(retryAfter) * 1000, 30_000)
-        : INITIAL_RETRY_DELAY_MS * 2 ** attempt;
+      const delayMs =
+        parseRetryAfter(response.headers.get("retry-after")) ??
+        INITIAL_RETRY_DELAY_MS * 2 ** attempt;
 
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      lastError = new Error(
-        `${label} failed: ${response.status} ${bodyText}`,
-      );
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, delayMs);
+        timer.unref?.();
+      });
+      lastError = failure;
       continue;
     }
 
-    throw new Error(`${label} failed: ${response.status} ${bodyText}`);
+    throw failure;
   }
 
   throw lastError ?? new Error(`${label} failed after retries`);
@@ -249,6 +323,7 @@ async function createLocalAuthorization(
 
   return new Promise((resolve, reject) => {
     let done = false;
+    let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let complete!: (value: string | null) => void;
     const wait = new Promise<string | null>((innerResolve) => {
@@ -287,9 +362,11 @@ async function createLocalAuthorization(
       }
 
       if (gotState !== state) {
+        // Reject the request but keep waiting. Aborting here let any local
+        // process - or any page in the user's browser, since this is a plain
+        // unauthenticated GET - cancel a login in flight with one bogus state.
         res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
         res.end("Invalid state");
-        finish(null);
         return;
       }
 
@@ -301,10 +378,23 @@ async function createLocalAuthorization(
       finish(url.toString());
     });
 
-    server.once("error", reject);
+    // `once` would both hide every post-listen error (the promise is already
+    // settled, so reject is a no-op) and consume the only handler - leaving a
+    // second 'error' event to crash the host Pi process as an unhandled event.
+    server.on("error", (error) => {
+      if (done || settled) {
+        finish(null);
+        return;
+      }
+      settled = true;
+      reject(error);
+    });
 
     server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
+      settled = true;
       timer = setTimeout(() => finish(null), LOCAL_CALLBACK_TIMEOUT);
+      // Never hold the event loop open on a login the user has abandoned.
+      timer.unref?.();
       resolve({
         redirectUri: `http://localhost:${CALLBACK_PORT}/callback`,
         waitForCallback: () => wait,
@@ -323,6 +413,13 @@ function makeCallbackPage(): string {
     <p>You can close this window and return to Pi.</p>
   </body>
 </html>`;
+}
+
+function settleGrace(): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, MANUAL_SETTLE_GRACE_MS);
+    timer.unref?.();
+  });
 }
 
 async function generatePKCE(): Promise<{
@@ -357,7 +454,9 @@ function parseAuthInput(input: string): ParsedAuthInput | null {
     const url = new URL(text);
     const code = url.searchParams.get("code");
     const state = url.searchParams.get("state");
-    if (code && state) return { code, state };
+    if (code && state) {
+      return { code, state, redirectUri: `${url.origin}${url.pathname}` };
+    }
   } catch {}
 
   const split = text.split("#");

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -245,10 +245,35 @@ export function convertPiMessagesToAnthropic(
     }
   }
 
+  // The loop only flushes when it reaches the next user message, so a history
+  // that *ends* on an assistant turn with unresolved tool calls ships orphan
+  // tool_use blocks - which Anthropic rejects outright - and lands the tail on
+  // an assistant message, where no breakpoint can go. The comment above always
+  // promised this ("or finish the history"); the call was missing.
+  flushPendingToolResults();
+
+  // Anthropic only looks for a cache hit at an explicit breakpoint, so the tail
+  // of the history has to carry one. A plain-text user turn arrives as a bare
+  // string with nowhere to hang cache_control, which used to drop the message
+  // breakpoint entirely on the first request of every turn - exactly when the
+  // history is longest - leaving the whole conversation to be reprocessed
+  // uncached. Promote it to a single text block so the breakpoint always lands.
   const last = params.at(-1);
-  if (last?.role === "user" && Array.isArray(last.content) && last.content.length > 0) {
-    const lastBlock = last.content[last.content.length - 1] as { cache_control?: { type: string } };
-    lastBlock.cache_control = { type: "ephemeral" };
+  if (last?.role === "user") {
+    if (typeof last.content === "string") {
+      if (last.content) {
+        last.content = [
+          {
+            type: "text",
+            text: last.content,
+            cache_control: { type: "ephemeral" },
+          },
+        ];
+      }
+    } else if (last.content.length > 0) {
+      const lastBlock = last.content[last.content.length - 1] as { cache_control?: { type: string } };
+      lastBlock.cache_control = { type: "ephemeral" };
+    }
   }
 
   return params;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -57,7 +57,14 @@ export function buildAnthropicSystemPrompt(
     });
   }
 
-  const sanitized = systemPrompt ? sanitizeSystemText(systemPrompt) : "";
+  // Repair surrogates before rewriting so the regex runs on well-formed text.
+  // Every other outbound string goes through sanitizeSurrogates in convert.ts;
+  // the system prompt was the one that did not, and an unpaired surrogate in it
+  // (a truncated emoji in project instructions, a file excerpt cut mid-codepoint)
+  // fails the request at JSON.stringify.
+  const sanitized = systemPrompt
+    ? sanitizeSystemText(sanitizeSurrogates(systemPrompt))
+    : "";
   if (sanitized) {
     blocks.push({
       type: "text",
@@ -109,12 +116,29 @@ function compileCustomPiRewritePattern(value: string | undefined): RegExp {
 
   const parsed = parseRegexLiteral(pattern) ?? { source: pattern, flags: "" };
   const flags = parsed.flags.includes("g") ? parsed.flags : `${parsed.flags}g`;
+
+  let compiled: RegExp;
   try {
-    return new RegExp(parsed.source, flags);
+    compiled = new RegExp(parsed.source, flags);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Invalid ${PI_REWRITE_PATTERN_ENV}: ${message}`);
   }
+
+  // A pattern that matches the empty string replaces at every position and
+  // shreds the system prompt into alternating replacement text. `//`, `/(?:)/`
+  // and a bare `(?:)` all land here - and `(?:)` is one keystroke away from the
+  // `(?!)` this project documents for disabling rewrites, so the typo is easy
+  // to make and its damage is silent.
+  const matchesEmpty = compiled.test("");
+  compiled.lastIndex = 0;
+  if (matchesEmpty) {
+    throw new Error(
+      `Invalid ${PI_REWRITE_PATTERN_ENV}: ${value} matches the empty string, which would replace at every position. Use a never-matching pattern such as (?!) to disable rewriting.`,
+    );
+  }
+
+  return compiled;
 }
 
 function parseRegexLiteral(value: string): { source: string; flags: string } | undefined {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -32,6 +32,32 @@ const REQUIRED_BETAS = [
   "interleaved-thinking-2025-05-14",
 ] as const;
 
+// budget_tokens is removed on every current Anthropic model and returns 400;
+// only the pre-4.6 generation still accepts it. Gate on the known-legacy shape
+// so unknown ids - future models, and the custom entries ~/.pi/agent/models.json
+// is documented to accept - default to adaptive, the path that works.
+const LEGACY_THINKING_MODEL =
+  /^claude-(?:opus|sonnet|haiku)-4-[0-5](?:-|$)|^claude-[0-3][-.]/;
+
+const MIN_THINKING_BUDGET = 1024;
+
+const EFFORT_BY_REASONING: Record<string, string> = {
+  minimal: "low",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+  max: "max",
+};
+
+export function usesAdaptiveThinking(model: Model<Api>): boolean {
+  const forced = (
+    model.compat as { forceAdaptiveThinking?: boolean } | undefined
+  )?.forceAdaptiveThinking;
+  if (typeof forced === "boolean") return forced;
+  return !LEGACY_THINKING_MODEL.test(model.id.toLowerCase().replace(/\./g, "-"));
+}
+
 function mapStopReason(reason: string | null | undefined): StopReason {
   switch (reason) {
     case "end_turn":
@@ -155,24 +181,40 @@ export function streamAnthropicOAuth(
         params.tools = convertPiToolsToAnthropic(context.tools, isOAuth);
 
       if (options?.reasoning && model.reasoning && maxTokens > 1) {
-        const defaultBudgets: Record<string, number> = {
-          minimal: 1024,
-          low: 4096,
-          medium: 10240,
-          high: 20480,
-          xhigh: 32000,
-        };
-        const customBudget =
-          options.thinkingBudgets?.[
-            options.reasoning as keyof typeof options.thinkingBudgets
-          ];
-        const requestedBudget =
-          customBudget ?? defaultBudgets[options.reasoning] ?? 10240;
+        if (usesAdaptiveThinking(model)) {
+          const mapped = model.thinkingLevelMap?.[options.reasoning];
+          const effort =
+            typeof mapped === "string"
+              ? mapped
+              : (EFFORT_BY_REASONING[options.reasoning] ?? "high");
+          // display defaults to "omitted" on every model that takes adaptive
+          // thinking, which streams thinking blocks with empty text - Pi renders
+          // those as a long silent pause. Ask for the summary explicitly.
+          params.thinking = { type: "adaptive", display: "summarized" } as never;
+          Object.assign(params, { output_config: { effort } });
+        } else {
+          const defaultBudgets: Record<string, number> = {
+            minimal: MIN_THINKING_BUDGET,
+            low: 4096,
+            medium: 10240,
+            high: 20480,
+            xhigh: 32000,
+          };
+          const customBudget =
+            options.thinkingBudgets?.[
+              options.reasoning as keyof typeof options.thinkingBudgets
+            ];
+          const requestedBudget =
+            customBudget ?? defaultBudgets[options.reasoning] ?? 10240;
+          const budget = Math.min(requestedBudget, maxTokens - 1);
 
-        params.thinking = {
-          type: "enabled",
-          budget_tokens: Math.min(requestedBudget, maxTokens - 1),
-        };
+          // Anthropic rejects budget_tokens below 1024. A small max_tokens (or an
+          // explicit budget of 0) would otherwise produce a request the API is
+          // guaranteed to refuse; skipping thinking degrades far better.
+          if (budget >= MIN_THINKING_BUDGET) {
+            params.thinking = { type: "enabled", budget_tokens: budget };
+          }
+        }
       }
 
       // Raw stream instead of the MessageStream helper: MessageStream
@@ -378,27 +420,44 @@ export function streamAnthropicOAuth(
         }
 
         if (event.type === "message_delta") {
-          output.stopReason = mapStopReason(event.delta.stop_reason);
-          output.usage.input =
-            (event.usage as { input_tokens?: number }).input_tokens ||
-            output.usage.input;
-          output.usage.output =
-            (event.usage as { output_tokens?: number }).output_tokens ||
-            output.usage.output;
-          output.usage.cacheRead =
-            (event.usage as { cache_read_input_tokens?: number })
-              .cache_read_input_tokens || 0;
-          output.usage.cacheWrite =
-            (event.usage as { cache_creation_input_tokens?: number })
-              .cache_creation_input_tokens || 0;
-          const thinkingTokens = (
-            event.usage as {
-              output_tokens_details?: { thinking_tokens?: number };
-            }
-          ).output_tokens_details?.thinking_tokens;
-          if (thinkingTokens != null) {
-            output.usage.reasoning = thinkingTokens;
+          // stop_reason is `StopReason | null`; mapping null lands in
+          // mapStopReason's default and yields "error", which convert.ts then
+          // treats as a poisoned turn and drops from the history entirely - so a
+          // fully streamed answer would silently vanish on the next request.
+          if (event.delta.stop_reason) {
+            output.stopReason = mapStopReason(event.delta.stop_reason);
           }
+
+          // Every usage field is nullable, and third-party gateways (baseUrl is
+          // caller-configurable) may omit the object outright. Only overwrite
+          // what is actually present - the values captured at message_start are
+          // the better fallback than zero, especially for the cache counters,
+          // which feed both cost and pricing-tier selection.
+          const usage = event.usage as
+            | {
+                input_tokens?: number | null;
+                output_tokens?: number | null;
+                cache_read_input_tokens?: number | null;
+                cache_creation_input_tokens?: number | null;
+                output_tokens_details?: { thinking_tokens?: number | null };
+              }
+            | undefined;
+
+          if (usage) {
+            if (usage.input_tokens != null) output.usage.input = usage.input_tokens;
+            if (usage.output_tokens != null) output.usage.output = usage.output_tokens;
+            if (usage.cache_read_input_tokens != null) {
+              output.usage.cacheRead = usage.cache_read_input_tokens;
+            }
+            if (usage.cache_creation_input_tokens != null) {
+              output.usage.cacheWrite = usage.cache_creation_input_tokens;
+            }
+            const thinkingTokens = usage.output_tokens_details?.thinking_tokens;
+            if (thinkingTokens != null) {
+              output.usage.reasoning = thinkingTokens;
+            }
+          }
+
           output.usage.totalTokens =
             output.usage.input +
             output.usage.output +
@@ -409,11 +468,19 @@ export function streamAnthropicOAuth(
       }
 
       if (options?.signal?.aborted) throw new Error("Request aborted");
-      stream.push({
-        type: "done",
-        reason: output.stopReason as "stop" | "length" | "toolUse",
-        message: output,
-      });
+      if (output.stopReason === "error") {
+        // Only reachable now via an unrecognized stop_reason string, which is a
+        // genuine error rather than a normal completion - don't dress it up as
+        // a "done" event whose declared reason it does not satisfy.
+        output.errorMessage ??= "Unrecognized stop reason from the API.";
+        stream.push({ type: "error", reason: "error", error: output });
+      } else {
+        stream.push({
+          type: "done",
+          reason: output.stopReason as "stop" | "length" | "toolUse",
+          message: output,
+        });
+      }
       stream.end();
     } catch (error) {
       for (const block of output.content as Array<{

--- a/test/convert.test.mjs
+++ b/test/convert.test.mjs
@@ -186,3 +186,172 @@ test("converts unsigned thinking to text and preserves tool-use ordering", () =>
     },
   ]);
 });
+
+test("puts a cache breakpoint on a plain-text user turn", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [{ role: "user", content: "Explain this repo", timestamp: 0 }],
+    true,
+    activeModel,
+  );
+
+  assert.deepEqual(converted, [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Explain this repo",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    },
+  ]);
+});
+
+test("puts a cache breakpoint on the last block of a structured user turn", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+        timestamp: 0,
+      },
+    ],
+    true,
+    activeModel,
+  );
+
+  assert.deepEqual(converted[0].content, [
+    { type: "text", text: "first" },
+    { type: "text", text: "second", cache_control: { type: "ephemeral" } },
+  ]);
+});
+
+test("breaks the cache only at the tail of the history", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      { role: "user", content: "first question", timestamp: 0 },
+      assistant([{ type: "text", text: "first answer" }]),
+      { role: "user", content: "second question", timestamp: 0 },
+    ],
+    true,
+    activeModel,
+  );
+
+  assert.equal(converted.length, 3);
+  // Earlier turns stay bare strings; only the tail carries the breakpoint.
+  assert.equal(converted[0].content, "first question");
+  assert.deepEqual(converted[2].content, [
+    {
+      type: "text",
+      text: "second question",
+      cache_control: { type: "ephemeral" },
+    },
+  ]);
+});
+
+test("puts a cache breakpoint on a tool-result turn", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      assistant([
+        { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "a" } },
+        { type: "toolCall", id: "tool-2", name: "read", arguments: { path: "b" } },
+      ]),
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        content: [{ type: "text", text: "a contents" }],
+        isError: false,
+        timestamp: 0,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tool-2",
+        toolName: "read",
+        content: [{ type: "text", text: "b contents" }],
+        isError: false,
+        timestamp: 0,
+      },
+    ],
+    true,
+    activeModel,
+  );
+
+  const results = converted[1].content;
+  assert.equal(results.length, 2);
+  assert.equal(results[0].cache_control, undefined);
+  assert.deepEqual(results[1].cache_control, { type: "ephemeral" });
+});
+
+test("sanitizes surrogates before promoting a user string to a block", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [{ role: "user", content: "lone \uD800 half", timestamp: 0 }],
+    true,
+    activeModel,
+  );
+
+  assert.deepEqual(converted[0].content, [
+    {
+      type: "text",
+      text: "lone � half",
+      cache_control: { type: "ephemeral" },
+    },
+  ]);
+});
+
+test("emits no breakpoint when the tail is an assistant turn", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [assistant([{ type: "text", text: "trailing answer" }])],
+    true,
+    activeModel,
+  );
+
+  assert.deepEqual(converted[0].content, [
+    { type: "text", text: "trailing answer" },
+  ]);
+});
+
+test("synthesizes tool results for a history ending on an unresolved tool call", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [
+      { role: "user", content: "do it", timestamp: 0 },
+      assistant([
+        { type: "toolCall", id: "t1", name: "read", arguments: { path: "a" } },
+      ]),
+    ],
+    true,
+    activeModel,
+  );
+
+  // The orphan tool_use must be answered, or Anthropic rejects the request.
+  assert.equal(converted.length, 3);
+  assert.deepEqual(converted[2], {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "t1",
+        content: "No result provided",
+        is_error: true,
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+  });
+});
+
+test("keeps the assistant tail bare when it has no pending tool calls", () => {
+  const converted = convertPiMessagesToAnthropic(
+    [assistant([{ type: "text", text: "trailing answer" }])],
+    true,
+    activeModel,
+  );
+
+  assert.equal(converted.length, 1);
+  assert.deepEqual(converted[0].content, [
+    { type: "text", text: "trailing answer" },
+  ]);
+});

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildAnthropicSystemPrompt,
   PI_REWRITE_MODE_ENV,
   PI_REWRITE_PATTERN_ENV,
   sanitizeSurrogates,
@@ -99,4 +100,44 @@ test("invalid rewrite configuration fails clearly", () => {
     () => sanitizeSystemText("Pi", rewriteEnv("custom", "(")),
     /Invalid PI_ANTHROPIC_OAUTH_REWRITE_PATTERN/,
   );
+});
+
+test("rejects custom patterns that match the empty string", () => {
+  for (const pattern of ["//", "/(?:)/", "(?:)", "/a*/"]) {
+    assert.throws(
+      () =>
+        sanitizeSystemText("Use the read tool.", {
+          [PI_REWRITE_MODE_ENV]: "custom",
+          [PI_REWRITE_PATTERN_ENV]: pattern,
+        }),
+      /matches the empty string/,
+      `expected ${pattern} to be rejected`,
+    );
+  }
+});
+
+test("still accepts the documented never-matching pattern", () => {
+  assert.equal(
+    sanitizeSystemText("Use pi to build.", {
+      [PI_REWRITE_MODE_ENV]: "custom",
+      [PI_REWRITE_PATTERN_ENV]: "(?!)",
+    }),
+    "Use pi to build.",
+  );
+});
+
+test("repairs unpaired surrogates in the system prompt", () => {
+  const blocks = buildAnthropicSystemPrompt("Read \uD800 the docs", false);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0].text, "Read � the docs");
+  assert.doesNotThrow(() => JSON.stringify(blocks));
+});
+
+test("prepends the Claude Code identity only under OAuth", () => {
+  const oauth = buildAnthropicSystemPrompt("Some instructions", true);
+  assert.equal(oauth.length, 2);
+  assert.match(oauth[0].text, /^You are Claude Code/);
+
+  const apiKey = buildAnthropicSystemPrompt("Some instructions", false);
+  assert.equal(apiKey.length, 1);
 });

--- a/test/stream.test.mjs
+++ b/test/stream.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { usesAdaptiveThinking } from "../.test-dist/stream.js";
+
+const gate = (id, compat) => usesAdaptiveThinking({ id, compat });
+
+test("routes current models to adaptive thinking", () => {
+  for (const id of [
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+  ]) {
+    assert.equal(gate(id), true, `${id} should use adaptive thinking`);
+  }
+});
+
+test("keeps pre-4.6 models on budget_tokens", () => {
+  for (const id of [
+    "claude-opus-4-5",
+    "claude-opus-4-5-20251101",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-1",
+    "claude-opus-4-0",
+    "claude-3-haiku-20240307",
+    "claude-3-5-sonnet-20241022",
+  ]) {
+    assert.equal(gate(id), false, `${id} should use budget_tokens`);
+  }
+});
+
+test("defaults unknown and future model ids to the path that works", () => {
+  // budget_tokens is removed API-wide, so an unrecognized id must not land there.
+  for (const id of [
+    "claude-opus-6",
+    "claude-sonnet-7-2",
+    "claude-mythos-preview",
+    "my-custom-anthropic-model",
+  ]) {
+    assert.equal(gate(id), true, `${id} should default to adaptive thinking`);
+  }
+});
+
+test("normalizes dotted model ids from models.json", () => {
+  assert.equal(gate("claude-opus-4.6"), true);
+  assert.equal(gate("claude-opus-4.5"), false);
+});
+
+test("honors an explicit compat override in both directions", () => {
+  assert.equal(gate("claude-opus-4-5", { forceAdaptiveThinking: true }), true);
+  assert.equal(gate("claude-opus-5", { forceAdaptiveThinking: false }), false);
+});


### PR DESCRIPTION
## What this fixes

Working through the OAuth path I ran into a set of bugs that either make Anthropic reject the request outright, or make Pi mishandle a response it received correctly. They are independent of each other — happy to split this into separate PRs if you would rather take them piecemeal.

### Requests the API rejects

**`budget_tokens` is removed API-wide** (`stream.ts`). It returns 400 on Opus 5, Opus 4.8/4.7, Sonnet 5 and Fable 5, and is deprecated on Opus 4.6 / Sonnet 4.6 — so with reasoning enabled the extension currently fails on every current model. Switched to adaptive thinking plus `output_config.effort`, keeping `budget_tokens` only for the pre-4.6 generation that still accepts it.

Two details worth calling out. Unknown model ids — future releases, and the custom entries `~/.pi/agent/models.json` is documented to accept — now default to **adaptive**, because that is the path that works; defaulting them to `budget_tokens` guarantees a 400. And `budget_tokens` is floored at the API's 1024 minimum, which a small `max_tokens` could previously undercut.

This overlaps with #27, which fixes the same root cause. I kept `display: "summarized"` from that PR — it is the right call, since the default is `"omitted"` on 4.7+ and thinking blocks otherwise stream empty. The differences: the model gate is inverted as described above, `xhigh`/`max` are no longer collapsed to `high`, and `display` is not sent on the legacy `type: "enabled"` branch, where it is not a documented field. Glad to drop this half if you would rather land #27 and take the delta as a follow-up.

**Orphan `tool_use` blocks** (`convert.ts`). `flushPendingToolResults()` is only called inside the loop, so a history that *ends* on an assistant turn with an unresolved tool call ships `tool_use` with no matching `tool_result` and the API refuses it. The comment above the helper already promised this behaviour ("or finish the history"); only the call was missing.

### Prompt caching never engaged for text turns

`cache_control` was attached only when the tail message had array content, but plain-text user turns are pushed as a bare string. On the first request of every turn — exactly when the history is longest — the request went out with no breakpoint in `messages`, so the whole conversation was reprocessed uncached. Breakpoints resumed once tool results started flowing, which is why this does not stand out in a single trace.

Related: `message_delta` reset `cache_read_input_tokens` / `cache_creation_input_tokens` to `0` rather than keeping the values captured at `message_start` — both fields are nullable, and `|| 0` swallows null. Cache reads therefore reported as zero tokens at zero cost, and can push `calculateCost` into the wrong pricing tier. `input`/`output` already had the correct fallback; only the two cache fields were missing it.

### Silent data loss

`delta.stop_reason` is `StopReason | null`, and `mapStopReason(null)` falls through to `"error"`. `convert.ts` then drops assistant turns with `stopReason === "error"` from the history — so a fully streamed turn, text and tool calls included, silently vanishes from the next request.

### Login flow

- The callback server and its five-minute timer were never torn down on failure paths. The process cannot exit, port 53692 stays bound, and a retried `/login` in the same session hits `EADDRINUSE` — which lands in the same empty `catch {}` and permanently downgrades the flow to manual paste.
- That blanket `catch {}` also made the entire `manualError` path dead code: cancelling the paste prompt re-showed the authorize URL instead of aborting. It now covers only failure to *start* the local server.
- Refresh treated every failure as transient, so a revoked or rotated refresh token retried every 30 seconds forever instead of prompting re-login. Added a typed error so only 429/5xx get the grace window.
- `Retry-After` in RFC 9110 HTTP-date form produced `NaN`, and `setTimeout(NaN)` fires immediately — so all three attempts hammered a server that had just asked to be backed off.
- A callback carrying a foreign `state` cancelled the login in progress. Since this is an unauthenticated `GET` on localhost, any local process or open page could abort a login with a single request. It now rejects that request and keeps waiting.
- `server.once("error", reject)` was a no-op after `listen` resolved *and* consumed the only handler, so a second `error` event would crash the host Pi process as an unhandled event.
- On fallback, the code was exchanged against the default `redirect_uri` even when the user had completed the browser flow against the localhost URL, failing with `invalid_grant`. The redirect is now taken from the pasted callback URL.

### Prompt rewriting

- A custom pattern matching the empty string replaces at every position and shreds the system prompt. `//`, `/(?:)/` and a bare `(?:)` all do this — and `(?:)` is one keystroke from the `(?!)` the README documents for disabling rewrites. Now rejected, with a message pointing at the right pattern.
- The system prompt was the only outbound string not passed through `sanitizeSurrogates`, despite the helper living in the same file. An unpaired surrogate there fails the request at `JSON.stringify` — the same failure class as #25.

## Testing

`npm run check`, `npm test` and `npm run pack:check` all pass. Test count goes 28 → 39; `test/stream.test.mjs` is new.

Worth noting that the suite previously contained no `role: "user"` message anywhere, so the tail-breakpoint logic was entirely uncovered. That is now a table test, alongside a model-id table for the thinking gate covering current, legacy, unknown and dotted ids.
